### PR TITLE
feat: add support for different kubectl versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ jobs:
       uses: steebchen/kubectl@master
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
+        KUBECTL_VERSION: "1.15"
       with:
         args: '"rollout status deployment/my-app"'
 ```
@@ -37,5 +38,9 @@ jobs:
 ```bash
 cat $HOME/.kube/config | base64
 ```
+
+## Environment
+
+`KUBECTL_VERSION` - (optional): Used to specify the kubectl version. If not specified, this defaults to kubectl 1.13
 
 **Note**: Do not use kubectl config view as this will hide the certificate-authority-data.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ set -e
 echo "$KUBE_CONFIG_DATA" | base64 --decode > /tmp/config
 export KUBECONFIG=/tmp/config
 
-sh -c "kubectl $*"
+sh -c "kubectl${KUBECTL_VERSION:+.${KUBECTL_VERSION}} $*"


### PR DESCRIPTION
Currently `entrypoint.sh` uses the default `kubectl` (version 1.13). This PR enables the selection of a different `kubectl` version with the optional `KUBECTL_VERSION` environment variable, as used in https://github.com/GoogleCloudPlatform/cloud-builders/blob/master/kubectl/kubectl.bash#L18, making newer features available for use.